### PR TITLE
Fixing empty discount value for shopping cart and order confirmation hooks

### DIFF
--- a/referralprogram.php
+++ b/referralprogram.php
@@ -292,7 +292,7 @@ class ReferralProgram extends Module
 
 		if ($cartRule->checkValidity($this->context, false, false) === true)
 		{
-			$this->smarty->assign(array('discount_display' => ReferralProgram::displayDiscount($cartRule->reduction_percent ? $cartRule->reduction_percent : $cartRule->reduction_amount, $cartRule->reduction_percent ? 1 : 2, new Currency($params['cookie']->id_currency)), 'discount' => $cartRule));
+			$this->smarty->assign(array('discount_display' => ReferralProgram::displayDiscount( (float) $cartRule->reduction_percent ? (float) $cartRule->reduction_percent : (int) $cartRule->reduction_amount,  (float) $cartRule->reduction_percent ? 1 : 2, new Currency($params['cookie']->id_currency)), 'discount' => $cartRule));
 			return $this->display(__FILE__, 'shopping-cart.tpl');
 		}
 		return false;
@@ -484,7 +484,7 @@ class ReferralProgram extends Module
 			$cartRule = new CartRule((int)$referralprogram->id_cart_rule_sponsor);
 			if (!Validate::isLoadedObject($cartRule))
 				return false;
-			$this->smarty->assign(array('discount' => ReferralProgram::displayDiscount($cartRule->reduction_percent ? $cartRule->reduction_percent : $cartRule->reduction_amount, $cartRule->reduction_percent ? 1 : 2, new Currency((int)$params['objOrder']->id_currency)), 'sponsor_firstname' => $sponsor->firstname, 'sponsor_lastname' => $sponsor->lastname));
+			$this->smarty->assign(array('discount' => ReferralProgram::displayDiscount( (float) $cartRule->reduction_percent ? (float) $cartRule->reduction_percent : (int) $cartRule->reduction_amount,  (float) $cartRule->reduction_percent ? 1 : 2, new Currency((int)$params['objOrder']->id_currency)), 'sponsor_firstname' => $sponsor->firstname, 'sponsor_lastname' => $sponsor->lastname));
 			return $this->display(__FILE__, 'order-confirmation.tpl');
 		}
 		return false;


### PR DESCRIPTION
displayDiscount does not work properly without casting to float/int - the ternary operators are passing wrong parameters to the function causing empty output for fixed amount reduction.
