### PR TITLE
Update shopping-cart.tpl

### DIFF
--- a/views/templates/hook/shopping-cart.tpl
+++ b/views/templates/hook/shopping-cart.tpl
@@ -27,7 +27,7 @@
 <p id="referralprogram">
 	<img src="{$module_template_dir}referralprogram.gif" alt="{l s='Referral program' mod='referralprogram'}" class="icon" />
 	{l s='You have earned a voucher worth %s thanks to your sponsor!' sprintf=$discount_display mod='referralprogram'}
-	{l s='Enter voucher name %s to receive the reduction on this order.' sprintf=$discount->name mod='referralprogram'}
+	{l s='Enter voucher name %s to receive the reduction on this order.' sprintf=$discount->code mod='referralprogram'}
 	<a href="{$link->getModuleLink('referralprogram', 'program', [], true)|escape:'html'}" title="{l s='Referral program' mod='referralprogram'}" rel="nofollow">{l s='View your referral program.' mod='referralprogram'}</a>
 </p>
 <br />


### PR DESCRIPTION
When a new invited customer wants to make his first order, only the name of the voucher is shown. (referral reward)
He is encouraged to enter this name but will fail to get the discount since it is not the voucer code.
This change corrects this.
